### PR TITLE
Added endpoint to support plucking fields from annotations.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules/
 # live config
 config.js
 .env
+.env.*
 
 # backups
 _backups/

--- a/package.json
+++ b/package.json
@@ -2,13 +2,14 @@
   "name": "MIT-Annotation-Data-Store",
   "version": "0.1.5",
   "dependencies": {
-    "jwt-simple": "0.1.0",
     "express": "3.4.4",
+    "jwt-simple": "0.1.0",
     "less-middleware": "0.1.12",
+    "lodash": "^4.16.1",
     "mongoose": "4.1.9"
   },
   "engines": {
-    "node": "0.10.21",
-    "npm": "1.3.11"
+    "node": "4.4.7",
+    "npm": "2.15.8"
   }
 }


### PR DESCRIPTION
#### What does this PR do?

Supports https://github.com/performant-software/Annotation-Studio/pull/78
#### Steps
1. Visit that app (http://cove-staging-pr-78.herokuapp.com/) **[NB; don't use https; it won't work]**
2. Annotate a document, using tags and categories
3. Add `/annotations/fields/tags.json` to the document view URL (eg: http://cove-staging-pr-78.herokuapp.com/documents/example/annotations/fields/tags.json)
4. Note that all tags you used are visible in the JSON response.
5. Same is true for http://cove-staging-pr-78.herokuapp.com/documents/example/annotations/fields/annotation_categories.json and http://cove-staging-pr-78.herokuapp.com/documents/example/annotations/fields/user.json, 
