### PR TITLE
Change annotation visibility to only show visible (or user's own) annotations on 'All' button select

### DIFF
--- a/web.js
+++ b/web.js
@@ -222,6 +222,8 @@ app.get('/api/search', tokenOK, function(req, res) {
     switch (req.query.mode) {
         case 'user':
             query.where('user').equals(req.query.user);
+            const userQueryString = `this.permissions.read.length < 1 || this.permissions.read.includes("${req.query.currentUser || req.query.user}")`;
+            query.$where(userQueryString);
             break;
         case 'group':
             query.where('subgroups'). in (req.query.subgroups);
@@ -235,8 +237,8 @@ app.get('/api/search', tokenOK, function(req, res) {
             query.limit(1);
             break;
         case 'admin':
-            const queryString = `this.permissions.read.length < 1 || this.permissions.read.includes("${req.query.user}")`;
-            query.$where(queryString);
+            const adminQueryString = `this.permissions.read.length < 1 || this.permissions.read.includes("${req.query.user}")`;
+            query.$where(adminQueryString);
             break;
     }
 

--- a/web.js
+++ b/web.js
@@ -235,6 +235,8 @@ app.get('/api/search', tokenOK, function(req, res) {
             query.limit(1);
             break;
         case 'admin':
+            const queryString = `this.permissions.read.length < 1 || this.permissions.read.includes("${req.query.user}")`;
+            query.$where(queryString);
             break;
     }
 


### PR DESCRIPTION
*** **NOTE - requires corresponding PR in Annotation Studio repo** *** - https://github.com/performant-software/Annotation-Studio/pull/355

**What this PR does:**

- Change query to filter for 
  (1) annotations that do not have visibility restrictions, or
  (2) annotations that the user has permission to read, 
when 'All' button is selected on annotation sidebar in Document view

**Steps to test:**

1. Create an annotation in a document ("Document A") from a given user account ("Account A"); ensure that 'My groups can view this annotation' checkbox is NOT checked. User account should be assigned to an anthology which contains the document being annotated.
2. Log out of Account A; log into a separate user account ("Account B") which is assigned to the same anthology that contains Document A. 
3. While logged into Account B, view Document A and click on the "All" button on the annotation sidebar on the right hand side of the screen; observe that the annotation made by Account A is NOT visible to Account B. 

**Visual change(s):**
N/A
